### PR TITLE
Address review feedback

### DIFF
--- a/FriendList/Models/Friend.swift
+++ b/FriendList/Models/Friend.swift
@@ -1,6 +1,8 @@
 import Foundation
 
-enum StatusType:Int {
+// Use `Codable` enum to represent friend status instead of raw integers.
+// This improves type safety when decoding JSON data.
+enum StatusType: Int, Codable {
     case invited, finish, inviting
 }
 
@@ -9,7 +11,8 @@ struct FriendListResponse: Codable {
 }
 
 struct Friend: Codable, Hashable {
-    let status: Int // 0:invited, 1:finished, 2:inviting
+    // Replace `Int` with strongly typed `StatusType` for better readability.
+    let status: StatusType
     let name: String
     let isTop: String // "0", "1"
     let fid: String // "001"

--- a/FriendList/Models/SegmentModel.swift
+++ b/FriendList/Models/SegmentModel.swift
@@ -8,6 +8,7 @@
 
 struct SegmentModel: Hashable {
     let title: String
-    let isSelect: Bool
+    // Rename to follow Swift naming convention.
+    let isSelected: Bool
     let badgeCount: Int
 }

--- a/FriendList/Services/ApiService.swift
+++ b/FriendList/Services/ApiService.swift
@@ -3,7 +3,8 @@ import Combine
 
 class ApiService {
     static let shared = ApiService()
-    private let baseURL = "https://dimanyen.github.io"
+    // Base URL now comes from `NetworkConfig` for easier maintenance.
+    private let baseURL = NetworkConfig.baseURL
 
     private init() {}
 

--- a/FriendList/Services/NetworkConfig.swift
+++ b/FriendList/Services/NetworkConfig.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+/// Central place for network related constants.
+struct NetworkConfig {
+    /// Base URL used for all API requests.
+    static let baseURL = "https://dimanyen.github.io"
+}

--- a/FriendList/ViewModels/FriendViewModel.swift
+++ b/FriendList/ViewModels/FriendViewModel.swift
@@ -12,6 +12,8 @@ class FriendViewModel {
     @Published var friends: [Friend] = []
     @Published var invites: [Friend] = []
     @Published private(set) var filteredFriends: [Friend] = []
+    // Expose error messages so the view controller can present them.
+    @Published var errorMessage: String?
     private let type: FriendListType
     private var cancellables = Set<AnyCancellable>()
     
@@ -22,13 +24,10 @@ class FriendViewModel {
     func fetchData() {
         ApiService.shared.fetchUserData()
             .receive(on: DispatchQueue.main)
-            .sink(receiveCompletion: { complete in
-                switch complete {
-                case .failure(let error):
-                    //TODO: error handle
-                    break
-                default: break
-                    //
+            .sink(receiveCompletion: { [weak self] complete in
+                // Capture any errors so the UI can react accordingly.
+                if case .failure(let error) = complete {
+                    self?.errorMessage = error.localizedDescription
                 }
                 
             }, receiveValue: { [weak self] users in
@@ -44,8 +43,11 @@ class FriendViewModel {
         case .friendsOnly:
             mergeTwoSources()
                 .receive(on: DispatchQueue.main)
-                .sink(receiveCompletion: { _ in
-                    //TODO: error handle
+                .sink(receiveCompletion: { [weak self] completion in
+                    if case .failure(let error) = completion {
+                        // Record the error so UI can display a message.
+                        self?.errorMessage = error.localizedDescription
+                    }
                 }, receiveValue: { [weak self] friends in
                     guard let self = self else { return }
                     self.friends = friends.sorted { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
@@ -58,15 +60,18 @@ class FriendViewModel {
         
         publisher
             .receive(on: DispatchQueue.main)
-            .sink(receiveCompletion: { _ in
-                //TODO: error handle
+            .sink(receiveCompletion: { [weak self] completion in
+                if case .failure(let error) = completion {
+                    // Forward the error message to the UI layer.
+                    self?.errorMessage = error.localizedDescription
+                }
             }, receiveValue: { [weak self] friends in
                 guard let self = self else { return }
                 self.invites = friends
-                    .filter { $0.status == StatusType.inviting.rawValue }
+                    .filter { $0.status == .inviting }
                     .sorted { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
                 self.friends = friends
-                    .filter { $0.status != StatusType.inviting.rawValue }
+                    .filter { $0.status != .inviting }
                     .sorted { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
             })
             .store(in: &cancellables)
@@ -88,7 +93,8 @@ class FriendViewModel {
         let all = list1 + list2
         
         for friend in all {
-            guard friend.status != StatusType.inviting.rawValue else { continue }
+            // Skip friends still in inviting state when merging lists.
+            guard friend.status != .inviting else { continue }
             if let existing = merged[friend.fid] {
                 let date1 = existing.updateDate.toDate() ?? Date.distantPast
                 let date2 = friend.updateDate.toDate() ?? Date.distantPast

--- a/FriendList/Views/FriendViewController.swift
+++ b/FriendList/Views/FriendViewController.swift
@@ -72,6 +72,17 @@ class FriendViewController: UIViewController {
                                    invites: self.viewModel?.invites ?? [])
             }
             .store(in: &cancellables)
+
+        // Show a simple alert whenever the view model reports an error.
+        viewModel.$errorMessage
+            .compactMap { $0 }
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] message in
+                let alert = UIAlertController(title: "Error", message: message, preferredStyle: .alert)
+                alert.addAction(UIAlertAction(title: "OK", style: .default))
+                self?.present(alert, animated: true)
+            }
+            .store(in: &cancellables)
     }
     
     private func updateUserInfoView(_ user: User) {
@@ -171,8 +182,8 @@ class FriendViewController: UIViewController {
         snapshot.appendItems(invites.map { .invite($0) }, toSection: .invite)
         
         let segments: [SegmentModel] = [
-            SegmentModel(title: "好友", isSelect: selectCateIndex == 0, badgeCount: invites.count),
-            SegmentModel(title: "聊天", isSelect: selectCateIndex == 1, badgeCount: friends.isEmpty ? 0 : 99)
+            SegmentModel(title: "好友", isSelected: selectCateIndex == 0, badgeCount: invites.count),
+            SegmentModel(title: "聊天", isSelected: selectCateIndex == 1, badgeCount: friends.isEmpty ? 0 : 99)
         ]
         snapshot.appendItems(segments.map { .segment($0) }, toSection: .segment)
         

--- a/FriendList/Views/cells/FriendCell.swift
+++ b/FriendList/Views/cells/FriendCell.swift
@@ -15,7 +15,8 @@ class FriendCell: BaseCollectionViewCell {
     func configure(with friend: Friend) {
         lblTitle.text = friend.name
         imgView.isHidden = !friend.isTopFriend()
-        btnInvite.isHidden = StatusType(rawValue: friend.status) != .invited
+        // Check status with enum directly after refactoring `Friend.status`.
+        btnInvite.isHidden = friend.status != .invited
         btnMore.isHidden = !btnInvite.isHidden
         btnAction.layer.borderColor = btnAction.tintColor.cgColor
         btnAction.layer.borderWidth = 1.0

--- a/FriendList/Views/cells/SegmentCell.swift
+++ b/FriendList/Views/cells/SegmentCell.swift
@@ -15,8 +15,8 @@ class SegmentCell: BaseCollectionViewCell {
     
     func configure(_ model: SegmentModel) {
         lblTitle.text = model.title
-        lblTitle.font = model.isSelect ? .boldSystemFont(ofSize: 13.0) : .systemFont(ofSize: 13.0)
-        viewHighlight.isHidden = !model.isSelect
+        lblTitle.font = model.isSelected ? .boldSystemFont(ofSize: 13.0) : .systemFont(ofSize: 13.0)
+        viewHighlight.isHidden = !model.isSelected
         lblBadge.text = (model.badgeCount > 98) ? "99+" : "\(model.badgeCount)"
         viewBadge.isHidden = model.badgeCount == 0
     }

--- a/FriendListTests/FriendListTests.swift
+++ b/FriendListTests/FriendListTests.swift
@@ -10,27 +10,20 @@ import XCTest
 
 final class FriendListTests: XCTestCase {
 
-    override func setUpWithError() throws {
-        // Put setup code here. This method is called before the invocation of each test method in the class.
+    func testMergeSelectsLatestFriend() {
+        let vm = FriendViewModel(type: .friendsOnly)
+        let old = Friend(status: .finish, name: "Bob", isTop: "0", fid: "001", updateDate: "20190101")
+        let new = Friend(status: .finish, name: "Bob", isTop: "0", fid: "001", updateDate: "20190201")
+        let result = vm.merge([old], [new])
+        XCTAssertEqual(result.count, 1)
+        XCTAssertEqual(result.first?.updateDate, "20190201")
     }
 
-    override func tearDownWithError() throws {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
-    }
-
-    func testExample() throws {
-        // This is an example of a functional test case.
-        // Use XCTAssert and related functions to verify your tests produce the correct results.
-        // Any test you write for XCTest can be annotated as throws and async.
-        // Mark your test throws to produce an unexpected failure when your test encounters an uncaught error.
-        // Mark your test async to allow awaiting for asynchronous code to complete. Check the results with assertions afterwards.
-    }
-
-    func testPerformanceExample() throws {
-        // This is an example of a performance test case.
-        self.measure {
-            // Put the code you want to measure the time of here.
-        }
+    func testMergeSkipsInviting() {
+        let vm = FriendViewModel(type: .friendsOnly)
+        let inviting = Friend(status: .inviting, name: "Sam", isTop: "0", fid: "002", updateDate: "20190102")
+        let result = vm.merge([], [inviting])
+        XCTAssertTrue(result.isEmpty)
     }
 
 }


### PR DESCRIPTION
## Summary
- use `StatusType` enum directly in `Friend`
- rename `isSelect` to `isSelected` for clarity
- centralize base URL in `NetworkConfig`
- handle errors in `FriendViewModel` and show alerts
- add unit tests for merge logic

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild -list` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686383654858832e9b6e418a8ac12b6e